### PR TITLE
Chore: Playstore compliance upgrade target (and compile) sdk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 android {
     namespace = "com.kusius.doughy"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         val major = 1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-minSdk = "28"
-android-targetSdk = "35"
+android-targetSdk = "36"
 androidGradlePlugin = "8.1.1"
 androidxActivity = "1.7.2"
 androidxComposeBom = "2023.08.00"


### PR DESCRIPTION
To keep application published on the play store.